### PR TITLE
Build skinny JAR and update to core lib 2.1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 
 - [libplctag4j](#libplctag4j)
   - [PLC Access Library for Java](#plc-access-library-for-java)
-    - [Dependencies](#dependencies)
-    - [Tier 1 Platforms](#tier-1-platforms)
+  - [Dependencies](#dependencies)
   - [Contact and Support](#contact-and-support)
     - [libplctag Forum](#libplctag-forum)
     - [GitHub](#github)
+  - [How to Use libplctag4j](#how-to-use-libplctag4j)
+    - [Build it Yourself](#build-it-yourself)
+  - [Tier 1 Platforms](#tier-1-platforms)
+  - [Tier 2 Platforms](#tier-2-platforms)
+  - [Android](#android)
   - [License](#license)
-  - [Full Release Requirements](#full-release-requirements)
+  - [TODO](#todo)
 
 Java wrapper for [libplctag](https://github.com/libplctag/libplctag).
 
@@ -16,19 +20,11 @@ Java wrapper for [libplctag](https://github.com/libplctag/libplctag).
 
 This library is a single JAR including all the needed parts to communicate with Allen-Bradley and some Modbus PLCs.   It uses the C-based project [libplctag](https://github.com/libplctag/libplctag) for the underlying protocol emulation.
 
-### Dependencies
+## Dependencies
 
-None!  The library includes all needed Java classes and includes backup copies of the native C libraries for the major Tier 1 platforms below.  Just drop it in your project and start building your application.
+None if you use a [Tier 1 platforms](#tier-1-platforms)!  The full JAR library includes all needed Java classes and includes backup copies of the native C libraries for the major Tier 1 platforms below.  Just drop it in your project and start building your application.
 
-### Tier 1 Platforms
-
-This library has full support for the following platforms:
-
-- Linux x86 and x64, Ubuntu/Debian
-- Microsoft Windows 10 x86 and x64
-- Apple macOS x64
-
-The C library will build on many of the platforms on which Java is available so support for other operating systems and CPUs is possible but not directly part of this library.   Patches and help gladly accepted!
+If you want to include the only the minimum, there is a second JAR file with just the classes for Tag.java and its inner classes built by the Gradle build.
 
 ## Contact and Support
 
@@ -49,26 +45,64 @@ ask questions and for discussions to happen.   Announcements about released happ
 If you find bugs or need specific features, please file them on GitHub's issue tracker for
 this project.
 
+## How to Use libplctag4j
+
+You can either take one of the releases from GitHub, unpack the ZIP file, and use the JAR files directly, or you can build it all yourself.   See the section below about Android for more information on how to use the library there.
+
+There are two JAR files.  The main one includes all of JNA and all the binaries required to use the library on the all the Tier 1 platforms except Android.   The JAR `libplctag_min_*.jar` includes only the minimum class files required.
+
+### Build it Yourself
+
+If you want to build the entire Java library yourself, you will need Git, Gradle 6+, the JDK of at least version 8, and an Internet connection for the first build.  Gradle will load everything you need.  Once all the dependencies are loaded, you can drop the Internet connection.
+
+For Intel/AMD-based Windows, Linux or macOS:
+
+1. Install Git, JDK 8+ and Gradle for your OS platform.
+2. Checkout the source with Git: `git clone https://github.com/libplctag/libplctag4j`
+3. In a command line window enter the directory/folder in which you checked out the project.
+4. Run `gradle build`
+5. You will find the JAR files in `build/libs`.
+
+You can use an IDE such as IntelliJ, Eclipse or Visual Studio Code.  All of these either natively handle the Gradle build files or have plugins that will support Gradle.
+
+## Tier 1 Platforms
+
+This library has full support for the following platforms:
+
+- Linux x86 and x64, Ubuntu/Debian
+- Microsoft Windows 10 x86 and x64
+- Apple macOS x64
+- [Android](https://github.com/libplctag/libplctag4android)
+
+The C library will build on many of the platforms on which Java is available so support for other operating systems and CPUs is possible but not directly part of this library.  See the section on [Tier 2 Platforms](#tier-2-platforms).   Patches and help gladly accepted!
+
+Note that using the library on Android is a more complicated process.  To make it easier, there is an example project for [Android](https://github.com/libplctag/libplctag4android) contributed by @GitHubDragonFly.
+
+## Tier 2 Platforms
+
+Tier 2 platforms are those on which the core library will build and Java and JNA are supported.  An example is the RaspberryPI series of small computers.  Any platform that supports either the Windows socket APIs or the POSIX networking and threading APIs will likely support the library, though perhaps with some effort.
+
+For these platforms:
+
+- Build the C library first and install it.
+- Install the JDK for your platform, at least version 8.
+- Install JNA for your platform.
+- Use the minimal JAR file with only the Tag classes.
+
+If you want to build the JAR files on your Tier 2 platform, you will also need to install Gradle.
+
+## Android
+
+There is another project in the libplctag organization for Android thanks to user @GitHubDragonFly.   Please see the [libplctag4android](https://github.com/libplctag/libplctag4android) project for a minimal example Android application.   This example shows how to include libplctag into your projects.
+
 ## License
 
-This code is released under a dual MPL (Mozilla Public License) 2.0/LGPL (Lesser/Library GNU Public License) 2+ license.   See the license files for more information.
+This code is released under the same dual MPL (Mozilla Public License) 2.0/LGPL (Lesser/Library GNU Public License) 2+ license as the C library.  See the license files for more information.
 
-## Full Release Requirements
+## TODO
 
-This library is not quite where it should be for a full 1.0 release.  The core functionality has been in heavy use since 2012 but has not been released as an independent project before.
+There are a few things left to do before this can be considered version 1.0.
 
-- [x] Get Tag.java compiling.
-- [x] Move to Gradle-based build.
-- [x] Separate out Java wrapper into separate repo.
-- [x] Include native DLL, JNA into single libplctag.java JAR.
-- [x] Support external DLLs for development and tier 2 platforms.
-- [x] Rename repo/project to libplctag4j.
-- [x] Add basic event callback support.
-- [x] Add basic logging callback support.
-- [x] Add basic unit tests.
-- [x] CI integration.
-- [ ] Create examples
-  - [ ] tag_rw clone.
-  - [ ] Tag listing.
-  - [ ] Callbacks.
-- [x] Documentation.
+- [x] Set up multiple JAR build.
+- [ ] Create stand-alone Java examples.
+- [ ] Export to Maven Central and/or JCentral.


### PR DESCRIPTION
Create two JARs now:

- A full JAR with all DLLs and supporting classes in it, including all of JNA.
- A minimal JAR with just the Tag classes.

Also update the core library to 2.1.18.

